### PR TITLE
Preventing IllegalArgumentException

### DIFF
--- a/src/main/java/technology/tabula/TextChunk.java
+++ b/src/main/java/technology/tabula/TextChunk.java
@@ -123,7 +123,7 @@ public class TextChunk extends RectangularTextContainer<TextElement> implements 
             else {
                 if (((lastChar != null && !lastChar.equals(currentChar)) || i + 1 == this.getTextElements().size()) && subSequenceLength >= minRunLength) {
 
-                    if (subSequenceStart == 0 && subSequenceLength < this.getTextElements().size() - 1) {
+                    if (subSequenceStart == 0 && subSequenceLength <= this.getTextElements().size() - 1) {
                         t = this.splitAt(subSequenceLength);
                     }
                     else {


### PR DESCRIPTION
The sqeeze(...) method failed, if there was a String like "       x". In that case, the method tried to run

t = this.splitAt(subSequenceStart);

That caused an IllegalArgumentException, because the sequence start was 0. I changed the condition in the upper if statement in order to cover these corner cases.