### PR TITLE
Add ObjectExtractor tests

### DIFF
--- a/src/main/java/technology/tabula/ObjectExtractor.java
+++ b/src/main/java/technology/tabula/ObjectExtractor.java
@@ -31,52 +31,43 @@ import org.apache.pdfbox.util.TextPosition;
 
 public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
 
-    class PointComparator implements Comparator<Point2D> {
-        @Override
-        public int compare(Point2D o1, Point2D o2) {
-            float o1X = Utils.round(o1.getX(), 2);
-            float o1Y = Utils.round(o1.getY(), 2);
-            float o2X = Utils.round(o2.getX(), 2);
-            float o2Y = Utils.round(o2.getY(), 2);
-
-            if (o1Y > o2Y)
-                return 1;
-            if (o1Y < o2Y)
-                return -1;
-            if (o1X > o2X)
-                return 1;
-            if (o1X < o2X)
-                return -1;
-            return 0;
-        }
-    }
-
     private static final char[] spaceLikeChars = { ' ', '-', '1', 'i' };
     private static final String NBSP = "\u00A0";
 
-    private float minCharWidth = Float.MAX_VALUE,
-            minCharHeight = Float.MAX_VALUE;
+    private float minCharWidth;
+    private float minCharHeight;
     private List<TextElement> characters;
     private List<Ruling> rulings;
     private RectangleSpatialIndex<TextElement> spatialIndex;
     private AffineTransform pageTransform;
-    private Shape clippingPath;
-    public List<Shape> clippingPaths = new ArrayList<Shape>();
-    private boolean debugClippingPaths = false;
-    private Rectangle2D transformedClippingPathBounds;
-    private Shape transformedClippingPath;
-    private boolean extractRulingLines = true;
+    public List<Shape> clippingPaths;
+    private boolean debugClippingPaths;
+    private boolean extractRulingLines;
     private final PDDocument pdf_document;
     protected List pdf_document_pages;
 
 
     public ObjectExtractor(PDDocument pdf_document) throws IOException {
-        this(pdf_document, null);
+        this(pdf_document, null, true, false);
     }
 
-    public ObjectExtractor(PDDocument pdf_document, String password)
+    public ObjectExtractor(PDDocument pdf_document, boolean debugClippingPaths) throws IOException {
+        this(pdf_document, null, true, debugClippingPaths);
+    }
+    
+    public ObjectExtractor(PDDocument pdf_document, String password) throws IOException {
+        this(pdf_document, password, true, false);
+    }
+
+    public ObjectExtractor(PDDocument pdf_document, String password, boolean extractRulingLines, boolean debugClippingPaths)
             throws IOException {
         super();
+        
+        this.clippingPaths = new ArrayList<Shape>();
+        this.debugClippingPaths = debugClippingPaths;
+        this.extractRulingLines = extractRulingLines;
+        
+        this.initialize();
         
         // patch PageDrawer: dummy Graphics2D context so some drawing operators don't complain
         try {
@@ -107,37 +98,36 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
 
     protected Page extractPage(Integer page_number) throws IOException {
 
-        if (page_number - 1 > this.pdf_document_pages.size() || page_number < 1) {
+        if (page_number > this.pdf_document_pages.size() || page_number < 1) {
             throw new java.lang.IndexOutOfBoundsException(
                     "Page number does not exist");
         }
+        this.initialize();
 
-        PDPage p = (PDPage) this.pdf_document_pages.get(page_number - 1);
-        PDStream contents = p.getContents();
-
-        if (contents == null) {
-            return null;
+        PDPage pdPage = (PDPage) this.pdf_document_pages.get(page_number - 1);
+        pdPage = this.drawPage(pdPage);
+        
+        if(pdPage != null) {
+        	
+        	Utils.sort(this.characters);
+        	
+        	float w, h;
+        	int pageRotation = pdPage.findRotation();
+        	if (Math.abs(pageRotation) == 90 || Math.abs(pageRotation) == 270) {
+        		w = pdPage.findCropBox().getHeight();
+        		h = pdPage.findCropBox().getWidth();
+        	}
+        	else {
+        		w = pdPage.findCropBox().getWidth();
+        		h = pdPage.findCropBox().getHeight();
+        	}
+        	
+        	return new Page(0, 0, w, h, pageRotation, page_number, this.characters,
+        			this.rulings, this.minCharWidth, this.minCharHeight,
+        			this.spatialIndex);
         }
-        this.clear();
+        return null;//TODO: content is empty, return null? or empty Page? or exception?
 
-        this.drawPage(p);
-
-        Utils.sort(this.characters);
-
-        float w, h;
-        int pageRotation = p.findRotation();
-        if (Math.abs(pageRotation) == 90 || Math.abs(pageRotation) == 270) {
-            w = p.findCropBox().getHeight();
-            h = p.findCropBox().getWidth();
-        }
-        else {
-            w = p.findCropBox().getWidth();
-            h = p.findCropBox().getHeight();
-        }
-
-        return new Page(0, 0, w, h, pageRotation, page_number, this.characters,
-                this.getRulings(), this.minCharWidth, this.minCharHeight,
-                this.spatialIndex);
     }
 
     public PageIterator extract(Iterable<Integer> pages) {
@@ -156,13 +146,15 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
         this.pdf_document.close();
     }
 
-    public void drawPage(PDPage p) throws IOException {
-        page = p;
+    private PDPage drawPage(PDPage p) throws IOException {
+        this.page = p;
         PDStream contents = p.getContents();
         if (contents != null) {
             ensurePageSize();
             this.processStream(p, p.findResources(), contents.getStream());
+            return p;
         }
+        return null;
     }
 
     private void ensurePageSize() {
@@ -173,7 +165,7 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
         }
     }
 
-    private void clear() {
+    private void initialize() {
         this.characters = new ArrayList<TextElement>();
         this.rulings = new ArrayList<Ruling>();
         this.pageTransform = null;
@@ -363,14 +355,6 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
 
     }
 
-    public float getMinCharWidth() {
-        return minCharWidth;
-    }
-
-    public float getMinCharHeight() {
-        return minCharHeight;
-    }
-
     public AffineTransform getPageTransform() {
 
         if (this.pageTransform != null) {
@@ -391,36 +375,19 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
         return this.pageTransform;
     }
 
-    //public Rectangle2D currentClippingPath() {
     public Rectangle2D currentClippingPath() {
-        // Shape cp = this.getGraphicsState().getCurrentClippingPath();
-        // if (cp == this.clippingPath) {
-        // return this.transformedClippingPathBounds;
-        // }
-
-        this.clippingPath = this.getGraphicsState().getCurrentClippingPath();
-        this.transformedClippingPath = this.getPageTransform()
-                .createTransformedShape(this.clippingPath);
-        this.transformedClippingPathBounds = this.transformedClippingPath
+   
+    	Shape clippingPath = this.getGraphicsState().getCurrentClippingPath();
+        Shape transformedClippingPath = this.getPageTransform()
+                .createTransformedShape(clippingPath);
+        Rectangle2D transformedClippingPathBounds = transformedClippingPath
                 .getBounds2D();
 
-        return this.transformedClippingPathBounds;
+        return transformedClippingPathBounds;
     }
 
     public boolean isExtractRulingLines() {
         return extractRulingLines;
-    }
-
-    public void setExtractRulingLines(boolean extractRulingLines) {
-        this.extractRulingLines = extractRulingLines;
-    }
-
-    public List<Ruling> getRulings() {
-        return rulings;
-    }
-
-    public List<TextElement> getCharacters() {
-        return characters;
     }
 
     private static boolean isPrintable(String s) {
@@ -434,12 +401,28 @@ public class ObjectExtractor extends org.apache.pdfbox.pdfviewer.PageDrawer {
         return debugClippingPaths;
     }
 
-    public void setDebugClippingPaths(boolean debugClippingPaths) {
-        this.debugClippingPaths = debugClippingPaths;
-    }
-
     public int getPageCount() {
         return this.pdf_document_pages.size();
+    }
+    
+    class PointComparator implements Comparator<Point2D> {
+        @Override
+        public int compare(Point2D o1, Point2D o2) {
+            float o1X = Utils.round(o1.getX(), 2);
+            float o1Y = Utils.round(o1.getY(), 2);
+            float o2X = Utils.round(o2.getX(), 2);
+            float o2Y = Utils.round(o2.getY(), 2);
+
+            if (o1Y > o2Y)
+                return 1;
+            if (o1Y < o2Y)
+                return -1;
+            if (o1X > o2X)
+                return 1;
+            if (o1X < o2X)
+                return -1;
+            return 0;
+        }
     }
 
 }

--- a/src/main/java/technology/tabula/debug/Debug.java
+++ b/src/main/java/technology/tabula/debug/Debug.java
@@ -211,8 +211,7 @@ public class Debug {
             boolean drawUnprocessedRulings, boolean drawProjectionProfile, boolean drawClippingPaths) throws IOException {
         PDDocument document = PDDocument.load(pdfPath);
         
-        ObjectExtractor oe = new ObjectExtractor(document);
-        oe.setDebugClippingPaths(drawClippingPaths);
+        ObjectExtractor oe = new ObjectExtractor(document, true);
         
         Page page = oe.extract(pageNumber + 1);
         

--- a/src/test/java/technology/tabula/TestObjectExtractor.java
+++ b/src/test/java/technology/tabula/TestObjectExtractor.java
@@ -56,9 +56,11 @@ public class TestObjectExtractor {
         PDDocument pdf_document = PDDocument.load("src/test/resources/technology/tabula/rotated_page.pdf");
         ObjectExtractor oe = new ObjectExtractor(pdf_document);
         PageIterator pi = oe.extract();
-        while (pi.hasNext()) {
-            pi.next();
-        }
+        
+        assertTrue(pi.hasNext());
+        assertNotNull(pi.next());
+        assertFalse(pi.hasNext());
+        
     }
     
     @Test
@@ -77,13 +79,49 @@ public class TestObjectExtractor {
         PDDocument pdf_document = PDDocument.load("src/test/resources/technology/tabula/labor.pdf");
         ObjectExtractor oe = new ObjectExtractor(pdf_document);
         PageIterator pi = oe.extract();
+        assertTrue(pi.hasNext());
         try {
             Page p = pi.next();
+            assertNotNull(p);
         }
         catch (NullPointerException e) {
             fail("NPE in ObjectExtractor " + e.toString());
         }
     }
     
+    @Test
+    public void testExtractOnePage() throws IOException{
+        PDDocument pdf_document = PDDocument.load("src/test/resources/technology/tabula/S2MNCEbirdisland.pdf");
+        assertEquals(2, pdf_document.getNumberOfPages());
+        
+        ObjectExtractor oe = new ObjectExtractor(pdf_document);
+        Page page = oe.extract(2);
+        
+        assertNotNull(page);
+    	
+    }
+    
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testExtractWrongPageNumber() throws IOException{
+        PDDocument pdf_document = PDDocument.load("src/test/resources/technology/tabula/S2MNCEbirdisland.pdf");
+        assertEquals(2, pdf_document.getNumberOfPages());
+        
+        ObjectExtractor oe = new ObjectExtractor(pdf_document);
+        oe.extract(3);
+    	
+    }
+    
+    @Test
+    public void testExtractWithoutExtractingRulings() throws IOException {
+        PDDocument pdf_document = PDDocument.load("src/test/resources/technology/tabula/should_detect_rulings.pdf");
+        ObjectExtractor oe = new ObjectExtractor(pdf_document, null, false, false);
+        PageIterator pi = oe.extract();
+       
+        assertTrue(pi.hasNext());
+        Page page = pi.next();
+        assertNotNull(page);
+        assertEquals(0, page.getRulings().size());
+        assertFalse(pi.hasNext());
+    }
     
 }


### PR DESCRIPTION
- Refactor ObjectExtractor creation and initialization, remove unused getters.
- Add more tests
- Fix extract wrong page number.

@jazzido I'm sorry, I've got missed of what is happening with Icdar tests so I started to continue adding more tests in tabula. I'm running a coverage tool to get the % of coverage tested in each class, ObjectExtract class has 86.8% now. Also I made some refactors in the class and I fixed a little bug about extracting an out of bound page number. 

After Matt can push his changes I could help making the icdar tests pass. 