### PR TITLE
Fix an infinite loop during clipping

### DIFF
--- a/src/main/java/technology/tabula/CohenSutherlandClipping.java
+++ b/src/main/java/technology/tabula/CohenSutherlandClipping.java
@@ -102,23 +102,23 @@ public final class CohenSutherlandClipping
 
             if ((c & LEFT) != INSIDE) {
                 qx = xMin;
-                qy = (qx-p1x)*slope + p1y;
+                qy = (Utils.feq(qx, p1x) ? 0 : qx-p1x)*slope + p1y;
             }
             else if ((c & RIGHT) != INSIDE) {
                 qx = xMax;
-                qy = (qx-p1x)*slope + p1y;
+                qy = (Utils.feq(qx, p1x) ? 0 : qx-p1x)*slope + p1y;
             }
             else if ((c & BOTTOM) != INSIDE) {
                 qy = yMin;
                 qx = vertical
                     ? p1x
-                    : (qy-p1y)/slope + p1x;
+                    : (Utils.feq(qy, p1y) ? 0 : qy-p1y)/slope + p1x;
             }
             else if ((c & TOP) != INSIDE) {
                 qy = yMax;
                 qx = vertical
                     ? p1x
-                    : (qy-p1y)/slope + p1x;
+                    : (Utils.feq(qy, p1y) ? 0 : qy-p1y)/slope + p1x;
             }
 
             if (c == c1) {


### PR DESCRIPTION
I ran into an issue extracting a page where the clipping algorithm would get put into an infinite loop due to some floating point math (because of an infinitesimal difference in points the region code would flip-flop back and forth between LEFT and BOTTOM and keep on calculating).

In cases where the difference between points is essentially 0 I just inserted 0 in place of the difference.