### PR TITLE
Fix numerous bugs in collapseOrientedRulings

### DIFF
--- a/src/test/java/technology/tabula/UtilsForTesting.java
+++ b/src/test/java/technology/tabula/UtilsForTesting.java
@@ -2,10 +2,7 @@ package technology.tabula;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.nio.charset.Charset;
 import java.util.List;
 
@@ -52,7 +49,7 @@ public class UtilsForTesting {
     
     public static String loadJson(String path) throws IOException {
     	
-    	BufferedReader reader = new BufferedReader( new FileReader (path));
+    	BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(path), "UTF-8"));
     	StringBuilder  stringBuilder = new StringBuilder();
     	String line = null;
     	


### PR DESCRIPTION
In particular, this closes #81 (you get CSV output instead of an exception). All tests still pass.

The bugs are that:

- The comparator was not transitive, which caused the exception in #81 
- The collapsing was assuming that start <= end for all lines
- A zero length line could end up in the result if it was the first thing in the input