### PR TITLE
Allow 'all' as an option for page debugging

### DIFF
--- a/src/main/java/technology/tabula/debug/Debug.java
+++ b/src/main/java/technology/tabula/debug/Debug.java
@@ -350,6 +350,20 @@ public class Debug {
                 }
                 area = new Rectangle(f.get(0), f.get(1), f.get(3) - f.get(1), f.get(2) - f.get(0));
             }
+
+            if (pages == null) {
+                // user specified all pages
+                PDDocument document = PDDocument.load(pdfFile.getAbsolutePath());
+
+                int numPages = document.getNumberOfPages();
+                pages = new ArrayList<Integer>(numPages);
+
+                for (int i = 1; i <= numPages; i++) {
+                    pages.add(i);
+                }
+
+                document.close();
+            }
             
             for (int i: pages) {
                 renderPage(pdfFile.getAbsolutePath(),


### PR DESCRIPTION
If you passed 'all' as a page parameter to the Debug utility a
NullPointerException was thrown. Instead now the code will find the number
of pages before attempting to spit out images for each.