### PR TITLE
Add Batch processing option to command line app

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Download a version of the tabula-java's jar, with all dependencies included, tha
 ```
 $ java -jar ./target/tabula-0.9.0-jar-with-dependencies.jar --help
 
-usage: tabula [-a <AREA>] [-c <COLUMNS>] [-d] [-f <FORMAT>] [-g] [-h] [-i]
+usage: tabula [-a <AREA>] [-b <DIRECTORY>] [-c <COLUMNS>] [-d] [-f <FORMAT>] [-g] [-h] [-i]
        [-n] [-o <OUTFILE>] [-p <PAGES>] [-r] [-s <PASSWORD>] [-u] [-v]
 
 Tabula helps you extract tables from PDFs
@@ -30,6 +30,8 @@ Tabula helps you extract tables from PDFs
                             --columns 10.1,20.2,30.3
  -d,--debug                 Print detected table areas instead of
                             processing.
+ -b,--batch <DIRECTORY>     Convert all .pdfs in the provided directory
+
  -f,--format <FORMAT>       Output format: (CSV,TSV,JSON). Default: CSV
  -g,--guess                 Guess the portion of the page to analyze per
                             page.

--- a/src/main/java/technology/tabula/CommandLineApp.java
+++ b/src/main/java/technology/tabula/CommandLineApp.java
@@ -81,6 +81,10 @@ public class CommandLineApp {
 
     public void extractTables(CommandLine line) throws ParseException {
         if (line.hasOption('b')) {
+          if (line.getArgs().length != 0) {
+              throw new ParseException("Filename specified with batch\nTry --help for help");
+          }
+
           File pdfDirectory = new File(line.getOptionValue('b'));
           if (!pdfDirectory.isDirectory()) {
             throw new ParseException("Directory does not exist or is not a directory");
@@ -276,7 +280,7 @@ public class CommandLineApp {
         o.addOption("u", "use-line-returns", false, "Use embedded line returns in cells. (Only in spreadsheet mode.)");
         o.addOption("d", "debug", false, "Print detected table areas instead of processing.");
         o.addOption(OptionBuilder.withLongOpt("batch")
-            .withDescription("Convert all .pdfs in the provided directory")
+            .withDescription("Convert all .pdfs in the provided directory.")
             .hasArg()
             .withArgName("DIRECTORY")
             .create("b"));

--- a/src/main/java/technology/tabula/CommandLineApp.java
+++ b/src/main/java/technology/tabula/CommandLineApp.java
@@ -36,6 +36,23 @@ public class CommandLineApp {
     private static String BANNER = "\nTabula helps you extract tables from PDFs\n\n";
 
     private Appendable defaultOutput;
+    private Rectangle pageArea;
+    private List<Integer> pages;
+    private OutputFormat outputFormat;
+    private String password;
+    private TableExtractor tableExtractor;
+
+    public CommandLineApp(Appendable defaultOutput, CommandLine line) throws ParseException {
+        this.defaultOutput = defaultOutput;
+        this.pageArea = CommandLineApp.whichArea(line);
+        this.pages = CommandLineApp.whichPages(line);
+        this.outputFormat = CommandLineApp.whichOutputFormat(line);
+        this.tableExtractor = CommandLineApp.createExtractor(line);
+
+        if (line.hasOption('s')) {
+          this.password = line.getOptionValue('s');
+        }
+    }
 
     public static void main(String[] args) {
         CommandLineParser parser = new GnuParser();
@@ -57,170 +74,148 @@ public class CommandLineApp {
                 throw new ParseException("Need one filename\nTry --help for help");
             }
 
-            new CommandLineApp(System.out).extractTables(line);
-
-        }
-        catch( ParseException exp ) {
+            new CommandLineApp(System.out, line).extractTables(line);
+        } catch(ParseException exp) {
             System.err.println("Error: " + exp.getMessage());
             System.exit(1);
         }
         System.exit(0);
     }
 
-    public CommandLineApp(Appendable defaultOutput) {
-		this.defaultOutput = defaultOutput;
-	}
-
     public void extractTables(CommandLine line) throws ParseException {
         File pdfFile = new File(line.getArgs()[0]);
         if (!pdfFile.exists()) {
             throw new ParseException("File does not exist");
         }
+        extractFileTables(line, pdfFile);
+    }
 
-        OutputFormat of = OutputFormat.CSV;
-        if (line.hasOption('f')) {
-            try {
-                of = OutputFormat.valueOf(line.getOptionValue('f'));
-            }
-            catch (IllegalArgumentException e) {
-                throw new ParseException(String.format(
-                        "format %s is illegal. Available formats: %s",
-                        line.getOptionValue('f'),
-                        Utils.join(",", OutputFormat.formatNames())));
-            }
-
-        }
-
+    public void extractFileTables(CommandLine line, File pdfFile) throws ParseException {
         Appendable outFile = this.defaultOutput;
+        if (!line.hasOption('o')) {
+          extractFile(pdfFile, this.defaultOutput);
+          return;
+        }
+
         BufferedWriter bufferedWriter = null;
-        if (line.hasOption('o')) {
-            File file = new File(line.getOptionValue('o'));
-
-            try {
-                file.createNewFile();
-                bufferedWriter = new BufferedWriter(new FileWriter(
-                        file.getAbsoluteFile()));
-                outFile = bufferedWriter;
-            } catch (IOException e) {
-                throw new ParseException("Cannot create file "
-                        + line.getOptionValue('o'));
-            }
-        }
-
-        Rectangle area = null;
-        if (line.hasOption('a')) {
-            List<Float> f = parseFloatList(line.getOptionValue('a'));
-            if (f.size() != 4) {
-                throw new ParseException("area parameters must be top,left,bottom,right");
-            }
-            area = new Rectangle(f.get(0), f.get(1), f.get(3) - f.get(1), f.get(2) - f.get(0));
-        }
-
-        List<Float> verticalRulingPositions = null;
-        if (line.hasOption('c')) {
-            verticalRulingPositions = parseFloatList(line.getOptionValue('c'));
-        }
-
-        String pagesOption = line.hasOption('p') ? line.getOptionValue('p') : "1";
-        List<Integer> pages = Utils.parsePagesOption(pagesOption);
-        ExtractionMethod method = whichExtractionMethod(line);
-        boolean useLineReturns = line.hasOption('u');
-
         try {
+            File file = new File(line.getOptionValue('o'));
+            FileWriter fileWriter = new FileWriter(file.getAbsoluteFile());
+            bufferedWriter = new BufferedWriter(fileWriter);
 
-            PDDocument pdfDocument = PDDocument.load(pdfFile);
+            file.createNewFile();
+            extractFile(pdfFile, bufferedWriter);
+        } catch (IOException e) {
+            throw new ParseException("Cannot create file " + line.getOptionValue('o'));
+        } finally {
+            if (bufferedWriter != null) {
+                try {
+                    bufferedWriter.close();
+                } catch (IOException e) {
+                    System.out.println("Error in closing the BufferedWriter" + e);
+                }
+            }
+        }
+    }
 
-            ObjectExtractor oe = line.hasOption('s') ?
-                    new ObjectExtractor(pdfDocument, line.getOptionValue('s')) :
-                    new ObjectExtractor(pdfDocument);
-            BasicExtractionAlgorithm basicExtractor = new BasicExtractionAlgorithm();
-            SpreadsheetExtractionAlgorithm spreadsheetExtractor = new SpreadsheetExtractionAlgorithm();
-
-            PageIterator pageIterator = pages == null ? oe.extract() : oe.extract(pages);
-            Page page;
+    private void extractFile(File pdfFile, Appendable outFile) throws ParseException {
+        PDDocument pdfDocument = null;
+        try {
+            pdfDocument = PDDocument.load(pdfFile);
+            PageIterator pageIterator = getPageIterator(pdfDocument);
             List<Table> tables = new ArrayList<Table>();
 
             while (pageIterator.hasNext()) {
-                page = pageIterator.next();
+                Page page = pageIterator.next();
 
-                if (area != null) {
-                    page = page.getArea(area);
-
+                if (pageArea != null) {
+                    page = page.getArea(pageArea);
                 }
 
-                if (method == ExtractionMethod.DECIDE) {
-                    method = spreadsheetExtractor.isTabular(page) ? ExtractionMethod.SPREADSHEET : ExtractionMethod.BASIC;
-                }
-
-                switch(method) {
-                case BASIC:
-                    if (line.hasOption('g')) {
-                        // guess the page areas to extract using a detection algorithm
-                        // currently we only have a detector that uses spreadsheets to find table areas
-                        DetectionAlgorithm detector = new NurminenDetectionAlgorithm();
-                        List<Rectangle> guesses = detector.detect(page);
-
-                        for (Rectangle guessRect : guesses) {
-                            Page guess = page.getArea(guessRect);
-                            tables.addAll(basicExtractor.extract(guess));
-                        }
-                    } else {
-                        tables.addAll(verticalRulingPositions == null ? basicExtractor.extract(page) : basicExtractor.extract(page, verticalRulingPositions));
-                    }
-
-                    break;
-                case SPREADSHEET:
-                    // TODO add useLineReturns
-                    tables.addAll(spreadsheetExtractor.extract(page));
-                default:
-                    break;
-                }
+                tables.addAll(tableExtractor.extractTables(page));
             }
-            writeTables(of, tables, outFile);
-
-
+            writeTables(tables, outFile);
         } catch (IOException e) {
             throw new ParseException(e.getMessage());
         } finally {
-        	if (bufferedWriter != null) {
-        		try {
-        			bufferedWriter.close();
-				} catch (IOException e) {
-					System.out.println("Error in closing the BufferedWriter" + e);
-				}
-        	}
+          try {
+              if (pdfDocument != null) {
+                pdfDocument.close();
+              }
+          } catch (IOException e) {
+              System.out.println("Error in closing pdf document" + e);
+          }
         }
-
     }
 
-    private void writeTables(OutputFormat format, List<Table> tables, Appendable out) throws IOException {
-        Writer writer = null;
-        switch (format) {
-        case CSV:
-            writer = new CSVWriter();
-            break;
-        case JSON:
-            writer = new JSONWriter();
-            break;
-        case TSV:
-            writer = new TSVWriter();
-            break;
-        }
-        writer.write(out, tables);
+    private PageIterator getPageIterator(PDDocument pdfDocument) throws IOException {
+        ObjectExtractor extractor = (this.password == null) ?
+                new ObjectExtractor(pdfDocument) :
+                new ObjectExtractor(pdfDocument, this.password);
+        PageIterator pageIterator = (pages == null) ?
+          extractor.extract() :
+          extractor.extract(pages);
+        return pageIterator;
     }
 
-    private ExtractionMethod whichExtractionMethod(CommandLine line) {
-        ExtractionMethod rv = ExtractionMethod.DECIDE;
+    // CommandLine parsing methods
+
+    private static OutputFormat whichOutputFormat(CommandLine line) throws ParseException {
+        if (!line.hasOption('f')) {
+            return OutputFormat.CSV;
+        }
+
+        try {
+            return OutputFormat.valueOf(line.getOptionValue('f'));
+        } catch (IllegalArgumentException e) {
+            throw new ParseException(String.format(
+                    "format %s is illegal. Available formats: %s",
+                    line.getOptionValue('f'),
+                    Utils.join(",", OutputFormat.formatNames())));
+        }
+    }
+
+    private static Rectangle whichArea(CommandLine line) throws ParseException {
+        if (!line.hasOption('a')) {
+          return null;
+        }
+
+        List<Float> f = parseFloatList(line.getOptionValue('a'));
+        if (f.size() != 4) {
+            throw new ParseException("area parameters must be top,left,bottom,right");
+        }
+        return new Rectangle(f.get(0), f.get(1), f.get(3) - f.get(1), f.get(2) - f.get(0));
+    }
+
+    private static List<Integer> whichPages(CommandLine line) throws ParseException {
+        String pagesOption = line.hasOption('p') ? line.getOptionValue('p') : "1";
+        return Utils.parsePagesOption(pagesOption);
+    }
+
+    private static ExtractionMethod whichExtractionMethod(CommandLine line) {
         if (line.hasOption('r')) {
-            rv = ExtractionMethod.SPREADSHEET;
+            return ExtractionMethod.SPREADSHEET;
         }
-        else if (line.hasOption('n') || line.hasOption('c') || line.hasOption('g')) {
-            rv = ExtractionMethod.BASIC;
+
+        if (line.hasOption('n') || line.hasOption('c') || line.hasOption('g')) {
+            return ExtractionMethod.BASIC;
         }
-        return rv;
+        return ExtractionMethod.DECIDE;
     }
 
+    private static TableExtractor createExtractor(CommandLine line) throws ParseException {
+      TableExtractor extractor = new TableExtractor();
+      extractor.setGuess(line.hasOption('g'));
+      extractor.setMethod(CommandLineApp.whichExtractionMethod(line));
+      extractor.setUseLineReturns(line.hasOption('u'));
 
+      if (line.hasOption('c')) {
+          extractor.setVerticalRulingPositions(parseFloatList(line.getOptionValue('c')));
+      }
+      return extractor;
+    }
+
+    // utilities, etc.
 
     public static List<Float> parseFloatList(String option) throws ParseException {
         String[] f = option.split(",");
@@ -287,6 +282,93 @@ public class CommandLineApp {
         return o;
     }
 
+    private static class TableExtractor {
+      private boolean guess = false;
+      private boolean useLineReturns = false;
+      private BasicExtractionAlgorithm basicExtractor = new BasicExtractionAlgorithm();
+      private SpreadsheetExtractionAlgorithm spreadsheetExtractor = new SpreadsheetExtractionAlgorithm();
+      private List<Float> verticalRulingPositions = null;
+      private ExtractionMethod method = ExtractionMethod.BASIC;
+
+      public TableExtractor() {
+      }
+
+      public void setVerticalRulingPositions(List<Float> positions) {
+        this.verticalRulingPositions = positions;
+      }
+
+      public void setGuess(boolean guess) {
+        this.guess = guess;
+      }
+
+      public void setUseLineReturns(boolean useLineReturns) {
+        this.useLineReturns = useLineReturns;
+      }
+
+      public void setMethod(ExtractionMethod method) {
+        this.method = method;
+      }
+
+      public List<Table> extractTables(Page page) {
+          ExtractionMethod effectiveMethod = this.method;
+          if (effectiveMethod == ExtractionMethod.DECIDE) {
+            effectiveMethod = spreadsheetExtractor.isTabular(page) ?
+              ExtractionMethod.SPREADSHEET :
+              ExtractionMethod.BASIC;
+          }
+          switch(effectiveMethod) {
+          case BASIC:
+              return extractTablesBasic(page);
+          case SPREADSHEET:
+              return extractTablesSpreadsheet(page);
+          default:
+            return new ArrayList<Table>();
+          }
+      }
+
+      public List<Table> extractTablesBasic(Page page) {
+        if (guess) {
+          // guess the page areas to extract using a detection algorithm
+          // currently we only have a detector that uses spreadsheets to find table areas
+          DetectionAlgorithm detector = new NurminenDetectionAlgorithm();
+          List<Rectangle> guesses = detector.detect(page);
+          List<Table> tables = new ArrayList<Table>();
+
+          for (Rectangle guessRect : guesses) {
+              Page guess = page.getArea(guessRect);
+              tables.addAll(basicExtractor.extract(guess));
+          }
+          return tables;
+        }
+
+        if (verticalRulingPositions != null) {
+          return basicExtractor.extract(page, verticalRulingPositions);
+        }
+        return basicExtractor.extract(page);
+      }
+
+      public List<Table> extractTablesSpreadsheet(Page page) {
+          // TODO add useLineReturns
+          return (List<Table>)spreadsheetExtractor.extract(page);
+      }
+    }
+
+    private void writeTables(List<Table> tables, Appendable out) throws IOException {
+        Writer writer = null;
+        switch (outputFormat) {
+        case CSV:
+            writer = new CSVWriter();
+            break;
+        case JSON:
+            writer = new JSONWriter();
+            break;
+        case TSV:
+            writer = new TSVWriter();
+            break;
+        }
+        writer.write(out, tables);
+    }
+
     private enum OutputFormat {
         CSV,
         TSV,
@@ -300,7 +382,6 @@ public class CommandLineApp {
             }
             return rv;
         }
-
     }
 
     private enum ExtractionMethod {

--- a/src/test/java/technology/tabula/TestCommandLineApp.java
+++ b/src/test/java/technology/tabula/TestCommandLineApp.java
@@ -17,7 +17,7 @@ public class TestCommandLineApp {
 		CommandLine cmd = parser.parse(CommandLineApp.buildOptions(), args);
 
 		StringBuilder stringBuilder = new StringBuilder();
-		new CommandLineApp(stringBuilder).extractTables(cmd);
+		new CommandLineApp(stringBuilder, cmd).extractTables(cmd);
 
 		return stringBuilder.toString();
 	}
@@ -26,7 +26,7 @@ public class TestCommandLineApp {
 	public void testExtractSpreadsheetWithArea() throws ParseException, IOException {
 
 		String expectedCsv = UtilsForTesting.loadCsv("src/test/resources/technology/tabula/csv/spreadsheet_no_bounding_frame.csv");
-		
+
 		assertEquals(expectedCsv, this.csvFromCommandLineArgs(new String[] {
 				"src/test/resources/technology/tabula/spreadsheet_no_bounding_frame.pdf",
 				"-p", "1", "-a",
@@ -39,7 +39,7 @@ public class TestCommandLineApp {
 	public void testExtractSpreadsheetWithAreaAndNewFile() throws ParseException, IOException {
 
 		String expectedCsv = UtilsForTesting.loadCsv("src/test/resources/technology/tabula/csv/spreadsheet_no_bounding_frame.csv");
-		
+
 		 this.csvFromCommandLineArgs(new String[] {
 					"src/test/resources/technology/tabula/spreadsheet_no_bounding_frame.pdf",
 					"-p", "1", "-a",
@@ -48,13 +48,13 @@ public class TestCommandLineApp {
 			});
 		//assertEquals(expectedCsv,);
 	}
-	
-	
+
+
 	@Test
 	public void testExtractJSONWithArea() throws ParseException, IOException {
 
 		String expectedJson = UtilsForTesting.loadJson("src/test/resources/technology/tabula/json/spanning_cells_basic.json");
-		
+
 		assertEquals(expectedJson, this.csvFromCommandLineArgs(new String[] {
 				"src/test/resources/technology/tabula/spanning_cells.pdf",
 				"-p", "1", "-a",
@@ -62,7 +62,7 @@ public class TestCommandLineApp {
 				"JSON"
 		}));
 	}
-	
+
 	@Test
 	public void testGuessOption() throws ParseException, IOException {
 		String expectedCsvNoGuessing = UtilsForTesting.loadCsv("src/test/resources/technology/tabula/csv/TestCommandLineApp_testGuessOption_no_guessing.csv");

--- a/src/test/java/technology/tabula/TestCommandLineApp.java
+++ b/src/test/java/technology/tabula/TestCommandLineApp.java
@@ -3,6 +3,10 @@ package technology.tabula;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -33,6 +37,30 @@ public class TestCommandLineApp {
 				"150.56,58.9,654.7,536.12", "-f",
 				"CSV"
 		}));
+	}
+
+	@Test
+	public void testExtractBatchSpreadsheetWithArea() throws ParseException, IOException {
+		FileSystem fs = FileSystems.getDefault();
+		String expectedCsv = UtilsForTesting.loadCsv("src/test/resources/technology/tabula/csv/spreadsheet_no_bounding_frame.csv");
+		Path tmpFolder = Files.createTempDirectory("tabula-java-batch-test");
+		tmpFolder.toFile().deleteOnExit();
+
+		Path copiedPDF = tmpFolder.resolve(fs.getPath("spreadsheet.pdf"));
+		Path sourcePDF = fs.getPath("src/test/resources/technology/tabula/spreadsheet_no_bounding_frame.pdf");
+		Files.copy(sourcePDF, copiedPDF);
+		copiedPDF.toFile().deleteOnExit();
+
+		this.csvFromCommandLineArgs(new String[] {
+				"-b", tmpFolder.toString(),
+				"-p", "1", "-a",
+				"150.56,58.9,654.7,536.12", "-f",
+				"CSV"
+		});
+
+		Path csvPath = tmpFolder.resolve(fs.getPath("spreadsheet.csv"));
+		assertTrue(csvPath.toFile().exists());
+		assertArrayEquals(expectedCsv.getBytes(), Files.readAllBytes(csvPath));
 	}
 
 	@Test


### PR DESCRIPTION
This change adds a -b option which converts all pdfs in a folder. The resulting files are named based on the original pdf, with the extension changed, depending on the format.

This change also includes a refactoring of the CommandLineApp class, so that the actual changes required for this were very minimal. I added a test for batch processing, and the other CommandLineApp tests are passing.