### PR TITLE
Test & fix bug in calculating bounds of 1 shape

### DIFF
--- a/src/main/java/technology/tabula/Utils.java
+++ b/src/main/java/technology/tabula/Utils.java
@@ -17,45 +17,45 @@ public class Utils {
     public static boolean within(double first, double second, double variance) {
         return second < first + variance && second > first - variance;
     }
-    
+
     public static boolean overlap(double y1, double height1, double y2, double height2, double variance) {
         return within( y1, y2, variance) || (y2 <= y1 && y2 >= y1 - height1) || (y1 <= y2 && y1 >= y2-height2);
     }
-    
+
     public static boolean overlap(double y1, double height1, double y2, double height2) {
         return overlap(y1, height1, y2, height2, 0.1f);
     }
-    
+
     private final static float EPSILON = 0.01f;
-    protected static boolean useQuickSort = useCustomQuickSort(); 
-    
+    protected static boolean useQuickSort = useCustomQuickSort();
+
     public static boolean feq(double f1, double f2) {
         return (Math.abs(f1 - f2) < EPSILON);
     }
-    
+
     public static float round(double d, int decimalPlace) {
         BigDecimal bd = new BigDecimal(Double.toString(d));
         bd = bd.setScale(decimalPlace, BigDecimal.ROUND_HALF_UP);
         return bd.floatValue();
     }
-    
+
     public static Rectangle bounds(Collection<? extends Shape> shapes) {
         if (shapes.isEmpty()) {
             throw new IllegalArgumentException("shapes can't be empty");
         }
-        
+
         Iterator<? extends Shape> iter = shapes.iterator();
         Rectangle rv = new Rectangle();
         rv.setRect(iter.next().getBounds2D());
 
-        do {
+        while (iter.hasNext()) {
             Rectangle2D.union(iter.next().getBounds2D(), rv, rv);
-        } while (iter.hasNext());
-        
+        }
+
         return rv;
-        
+
     }
-    
+
     // range iterator
     public static List<Integer> range(final int begin, final int end) {
         return new AbstractList<Integer>() {
@@ -70,7 +70,7 @@ public class Utils {
             }
         };
     }
-    
+
 
     /* from apache.commons-lang */
     public static boolean isNumeric(final CharSequence cs) {
@@ -85,7 +85,7 @@ public class Utils {
         }
         return true;
     }
-    
+
     public static String join(String glue, String...s) {
         int k = s.length;
         if ( k == 0 )
@@ -100,7 +100,7 @@ public class Utils {
         }
         return out.toString();
     }
-    
+
     public static <T> List<List<T>> transpose(List<List<T>> table) {
         List<List<T>> ret = new ArrayList<List<T>>();
         final int N = table.get(0).size();
@@ -116,7 +116,7 @@ public class Utils {
 
     /**
      * Wrap Collections.sort so we can fallback to a non-stable quicksort
-     * if we're running on JDK7+ 
+     * if we're running on JDK7+
      */
     public static <T extends Comparable<? super T>> void sort(List<T> list) {
         if (useQuickSort) {
@@ -126,10 +126,10 @@ public class Utils {
             Collections.sort(list);
         }
     }
-    
+
     private static boolean useCustomQuickSort() {
         // taken from PDFBOX:
-        
+
         // check if we need to use the custom quicksort algorithm as a
         // workaround to the transitivity issue of TextPositionComparator:
         // https://issues.apache.org/jira/browse/PDFBOX-1512
@@ -151,36 +151,36 @@ public class Utils {
         String useLegacySort = System.getProperty("java.util.Arrays.useLegacyMergeSort");
         return !is16orLess || (useLegacySort != null && useLegacySort.equals("true"));
     }
-    
-    
-    
+
+
+
     public static List<Integer> parsePagesOption(String pagesSpec) throws ParseException {
         if (pagesSpec.equals("all")) {
             return null;
         }
-        
+
         List<Integer> rv = new ArrayList<Integer>();
-        
+
         String[] ranges = pagesSpec.split(",");
         for (int i = 0; i < ranges.length; i++) {
             String[] r = ranges[i].split("-");
             if (r.length == 0 || !Utils.isNumeric(r[0]) || r.length > 1 && !Utils.isNumeric(r[1])) {
                 throw new ParseException("Syntax error in page range specification");
             }
-            
+
             if (r.length < 2) {
                 rv.add(Integer.parseInt(r[0]));
             }
             else {
                 int t = Integer.parseInt(r[0]);
-                int f = Integer.parseInt(r[1]); 
+                int f = Integer.parseInt(r[1]);
                 if (t > f) {
                     throw new ParseException("Syntax error in page range specification");
                 }
-                rv.addAll(Utils.range(t, f+1));       
+                rv.addAll(Utils.range(t, f+1));
             }
         }
-        
+
         Collections.sort(rv);
         return rv;
     }

--- a/src/test/java/technology/tabula/TestUtils.java
+++ b/src/test/java/technology/tabula/TestUtils.java
@@ -15,12 +15,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestUtils {
-    
-    public static final Ruling[] RULINGS = { 
+
+    public static final Ruling[] RULINGS = {
         new Ruling(new Point2D.Float(0, 0), new Point2D.Float(1,1)),
-        new Ruling(new Point2D.Float(2, 2), new Point2D.Float(3,3)) 
+        new Ruling(new Point2D.Float(2, 2), new Point2D.Float(3,3))
     };
-    
+
     public static final Rectangle[] RECTANGLES = {
         new Rectangle(),
         new Rectangle(0, 0, 2, 4)
@@ -35,29 +35,37 @@ public class TestUtils {
         assertEquals(3, r.getWidth(), 0);
         assertEquals(3, r.getHeight(), 0);
     }
-    
+
     @Test
     public void testBoundsOfOneEmptyRectangleAndAnotherNonEmpty() {
         Rectangle r = Utils.bounds(Arrays.asList(RECTANGLES));
         assertEquals(r, RECTANGLES[1]);
     }
-    
+
+    @Test
+    public void testBoundsOfOneRectangle() {
+        ArrayList<Rectangle> shapes = new ArrayList();
+        shapes.add(new Rectangle(0, 0, 20, 40));
+        Rectangle r = Utils.bounds(shapes);
+        assertEquals(r, shapes.get(0));
+    }
+
     @Test
     public void testParsePagesOption() throws ParseException {
-        
+
         List<Integer> rv = Utils.parsePagesOption("1");
         assertArrayEquals(new Integer[] { 1 }, rv.toArray());
-        
+
         rv = Utils.parsePagesOption("1-4");
         assertArrayEquals(new Integer[] { 1,2,3,4 }, rv.toArray());
-        
+
         rv = Utils.parsePagesOption("1-4,20-24");
         assertArrayEquals(new Integer[] { 1,2,3,4,20,21,22,23,24 }, rv.toArray());
-        
+
         rv = Utils.parsePagesOption("all");
         assertNull(rv);
     }
-    
+
     @Test(expected=ParseException.class)
     public void testExceptionInParsePages() throws ParseException {
         Utils.parsePagesOption("1-4,24-22");
@@ -72,39 +80,39 @@ public class TestUtils {
     public void testQuickSortEmptyList() {
     	List<Integer> numbers = new ArrayList<Integer>();
     	QuickSort.sort(numbers);
-    	
+
     	assertEquals(Collections.emptyList(), numbers);
     }
-    
+
     @Test
     public void testQuickSortOneElementList() {
     	List<Integer> numbers = Arrays.asList(5);
     	QuickSort.sort(numbers);
-    	
+
     	assertEquals(Arrays.asList(5), numbers);
     }
-    
+
     @Test
     public void testQuickSortShortList() {
     	List<Integer> numbers = Arrays.asList(4, 5, 6, 8, 7, 1, 2, 3);
     	QuickSort.sort(numbers);
-    	
+
     	assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8), numbers);
     }
-    
+
     @Test
     public void testQuickSortLongList() {
-    	
+
     	List<Integer> numbers = new ArrayList<Integer>();
     	List<Integer> expectedNumbers = new ArrayList<Integer>();
-    	
+
     	for(int i = 0; i <= 12000; i++){
     		numbers.add(12000 - i);
     		expectedNumbers.add(i);
     	}
-    	
+
     	QuickSort.sort(numbers);
-    	
+
     	assertEquals(expectedNumbers, numbers);
     }
 


### PR DESCRIPTION
This bug resulted in an exception being thrown for some PDFs, which kills the tabula-java CLI.

[nearly_empty.pdf](https://github.com/tabulapdf/tabula-java/files/459737/nearly_empty.pdf) is an example pdf which triggers this bug. It extracts correctly with this patch applied.

Except for the first iter.next(), which is protected by shapes.isEmpty(), we must call iter.hasNext() before each call to iter.next().