### PR TITLE
replace Collections.sort with tabula.Utils.sort where possible

### DIFF
--- a/src/main/java/technology/tabula/Cell.java
+++ b/src/main/java/technology/tabula/Cell.java
@@ -31,7 +31,7 @@ public class Cell extends RectangularTextContainer<TextChunk> {
             return "";
         }
         StringBuilder sb = new StringBuilder();
-        Collections.sort(this.textElements);
+        Utils.sort(this.textElements);
         double curTop = this.textElements.get(0).getTop();
         for (TextChunk tc: this.textElements) {
             if (useLineReturns && tc.getTop() > curTop) {

--- a/src/main/java/technology/tabula/ProjectionProfile.java
+++ b/src/main/java/technology/tabula/ProjectionProfile.java
@@ -1,7 +1,6 @@
 package technology.tabula;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 
@@ -92,7 +91,7 @@ public class ProjectionProfile {
             }
             foundNarrower = false;
         }
-        Collections.sort(verticalSeparators);
+        Utils.sort(verticalSeparators);
         float[] rv = new float[verticalSeparators.size()];
         for (int i = 0; i < rv.length; i++) {
             rv[i] = (float) toDouble(verticalSeparators.get(i));
@@ -125,7 +124,7 @@ public class ProjectionProfile {
             }
             foundShorter = false;
         }
-        Collections.sort(horizontalSeparators);
+        Utils.sort(horizontalSeparators);
         float[] rv = new float[horizontalSeparators.size()];
         for (int i = 0; i < rv.length; i++) {
             rv[i] = (float) toDouble(horizontalSeparators.get(i));

--- a/src/main/java/technology/tabula/detectors/SpreadsheetDetectionAlgorithm.java
+++ b/src/main/java/technology/tabula/detectors/SpreadsheetDetectionAlgorithm.java
@@ -6,9 +6,9 @@ import technology.tabula.Page;
 import technology.tabula.Rectangle;
 import technology.tabula.Ruling;
 import technology.tabula.extractors.SpreadsheetExtractionAlgorithm;
+import technology.tabula.Utils;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -28,7 +28,7 @@ public class SpreadsheetDetectionAlgorithm implements DetectionAlgorithm {
         List<Rectangle> tables = sea.findSpreadsheetsFromCells(cells);
 
         // we want tables to be returned from top to bottom on the page
-        Collections.sort(tables);
+        Utils.sort(tables);
 
         return tables;
     }

--- a/src/main/java/technology/tabula/extractors/BasicExtractionAlgorithm.java
+++ b/src/main/java/technology/tabula/extractors/BasicExtractionAlgorithm.java
@@ -13,6 +13,7 @@ import technology.tabula.Ruling;
 import technology.tabula.Table;
 import technology.tabula.TextChunk;
 import technology.tabula.TextElement;
+import technology.tabula.Utils;
 
 public class BasicExtractionAlgorithm implements ExtractionAlgorithm {
     
@@ -155,7 +156,7 @@ public class BasicExtractionAlgorithm implements ExtractionAlgorithm {
             rv.add((float) r.getRight());
         }
         
-        Collections.sort(rv);
+        Utils.sort(rv);
         
         return rv;
         

--- a/src/main/java/technology/tabula/extractors/SpreadsheetExtractionAlgorithm.java
+++ b/src/main/java/technology/tabula/extractors/SpreadsheetExtractionAlgorithm.java
@@ -238,7 +238,7 @@ public class SpreadsheetExtractionAlgorithm implements ExtractionAlgorithm {
         
         cells = new ArrayList<Rectangle>(new HashSet<Rectangle>(cells));
         
-        Collections.sort(cells);
+        Utils.sort(cells);
         
         for (Rectangle cell: cells) {
             for(Point2D pt: cell.getPoints()) {

--- a/src/test/java/technology/tabula/TestRectangle.java
+++ b/src/test/java/technology/tabula/TestRectangle.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.awt.geom.Point2D;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
@@ -96,7 +95,7 @@ public class TestRectangle {
 		toSortList.add(first);
 		toSortList.add(fourth);
 		
-		Collections.sort(toSortList);
+		Utils.sort(toSortList);
 		
 		assertEquals(expectedList, toSortList);
 	}

--- a/src/test/java/technology/tabula/TestSpreadsheetExtractor.java
+++ b/src/test/java/technology/tabula/TestSpreadsheetExtractor.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.*;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -254,9 +253,9 @@ public class TestSpreadsheetExtractor {
     @Test
     public void testLinesToCells() {
         List<Cell> cells = SpreadsheetExtractionAlgorithm.findCells(Arrays.asList(HORIZONTAL_RULING_LINES), Arrays.asList(VERTICAL_RULING_LINES));
-        Collections.sort(cells);
+        Utils.sort(cells);
         List<Cell> expected = Arrays.asList(EXPECTED_CELLS);
-        Collections.sort(expected);
+        Utils.sort(expected);
         assertTrue(cells.equals(expected));
     }
     
@@ -286,9 +285,9 @@ public class TestSpreadsheetExtractor {
         SpreadsheetExtractionAlgorithm se = new SpreadsheetExtractionAlgorithm();
         List<? extends Rectangle> cells = Arrays.asList(CELLS);
         List<Rectangle> expected = Arrays.asList(EXPECTED_RECTANGLES);
-        Collections.sort(expected);
+        Utils.sort(expected);
         List<Rectangle> foundRectangles = se.findSpreadsheetsFromCells(cells);
-        Collections.sort(foundRectangles);
+        Utils.sort(foundRectangles);
         assertTrue(foundRectangles.equals(expected));
     }
     


### PR DESCRIPTION
fixes #116 in the case I encountered in the wild

note that there are still calls to Collections.sort present, where the comparator function is given in the call itself. Ideally, Utils.sort should gain a way to receive a Comparator as well, but that's a bit over my paygrade, java-skills-wise.