### PR TITLE
ensure mergeWords is idempotent

### DIFF
--- a/src/main/java/technology/tabula/TextElement.java
+++ b/src/main/java/technology/tabula/TextElement.java
@@ -118,7 +118,12 @@ public class TextElement extends Rectangle implements HasText {
             return textChunks;
         }
         
-        textChunks.add(new TextChunk(textElements.remove(0)));
+        // it's a problem that this `remove` is side-effecty
+        // other things depend on `textElements` and it can sometimes lead to the first textElement in textElement
+        // not appearing in the final output because it's been removed here.
+        // https://github.com/tabulapdf/tabula-java/issues/78
+        List<TextElement> copyOfTextElements = new ArrayList<TextElement>(textElements);
+        textChunks.add(new TextChunk(copyOfTextElements.remove(0)));
         TextChunk firstTC = textChunks.get(0); 
         
         float previousAveCharWidth = (float) firstTC.getWidth();
@@ -133,7 +138,7 @@ public class TextElement extends Rectangle implements HasText {
         TextChunk currentChunk;
         boolean sameLine, acrossVerticalRuling;
         
-        for (TextElement chr : textElements) {
+        for (TextElement chr : copyOfTextElements) {
             currentChunk = textChunks.get(textChunks.size() - 1);
             prevChar = currentChunk.textElements.get(currentChunk.textElements.size() - 1);
             

--- a/src/test/java/technology/tabula/TestTextElement.java
+++ b/src/test/java/technology/tabula/TestTextElement.java
@@ -93,6 +93,24 @@ public class TestTextElement {
 	}
 	
 	@Test
+	public void mergeElementsShouldBeIdempotent() {
+		/*
+	   * a bug in TextElement.merge_words would delete the first TextElement in the array
+	   * it was called with. Discussion here: https://github.com/tabulapdf/tabula-java/issues/78
+	   */
+
+		List<TextElement> elements = new ArrayList<TextElement>();
+		elements.add(new TextElement(0f, 15f, 10f, 20f, PDType1Font.HELVETICA, 1f, "A", 1f, 6f));
+		elements.add(new TextElement(0f, 25f, 10f, 20f, PDType1Font.HELVETICA, 1f, "B", 1f, 6f));
+		elements.add(new TextElement(0f, 35f, 10f, 20f, PDType1Font.HELVETICA, 1f, "C", 1f, 6f));
+		elements.add(new TextElement(0f, 45f, 10f, 20f, PDType1Font.HELVETICA, 1f, "D", 1f, 6f));
+		
+		List<TextChunk> words = TextElement.mergeWords(elements);
+		List<TextChunk> words2 = TextElement.mergeWords(elements);
+		Assert.assertEquals(words, words2);
+	}
+
+	@Test
 	public void mergeElementsWithSkippingRules() {
 		
 		List<TextElement> elements = new ArrayList<TextElement>();


### PR DESCRIPTION
Currently, we `delete` the first element of the arraylist argument to mergeWords. This modifies that arraylist, so if mergeWords is called twice, its result will be missing the first textElement. That's not good (and was reported by @douglasropb in #87).

This bugfix fixes the problem. I've included a test. @jazzido: I don't know much about benchmarking and Java memory management, so it's possible this is an inefficient solution. Please let me know if so...