### PR TITLE
ignore area if the page has no text. closes #130

### DIFF
--- a/src/main/java/technology/tabula/Page.java
+++ b/src/main/java/technology/tabula/Page.java
@@ -53,6 +53,7 @@ public class Page extends Rectangle {
     
     public Page getArea(Rectangle area) {
         List<TextElement> t = getText(area);
+        if (t.isEmpty()) return this;
         Page rv = new Page(
                 (float) area.getTop(),
                 (float) area.getLeft(),


### PR DESCRIPTION
Basically ignore the page with area restrictions creation when there's no text elements on the page
https://github.com/jjelosua/tabula-java/blob/master/src/main/java/technology/tabula/Page.java#L56