### PR TITLE
return empty text for empty areas 

### DIFF
--- a/src/main/java/technology/tabula/Page.java
+++ b/src/main/java/technology/tabula/Page.java
@@ -53,6 +53,21 @@ public class Page extends Rectangle {
     
     public Page getArea(Rectangle area) {
         List<TextElement> t = getText(area);
+        float min_char_width  = 7;
+        float min_char_height = 7;
+
+        if(t.size() > 0){
+            min_char_width = Collections.min(t, new Comparator<TextElement>() {
+                                    @Override
+                                    public int compare(TextElement te1, TextElement te2) {
+                                        return java.lang.Float.compare(te1.width, te2.width);
+                                 }}).width;
+            min_char_height = Collections.min(t, new Comparator<TextElement>() {
+                                        @Override
+                                        public int compare(TextElement te1, TextElement te2) {
+                                            return java.lang.Float.compare(te1.height, te2.height);
+                                  }}).height;
+        }
         Page rv = new Page(
                 (float) area.getTop(),
                 (float) area.getLeft(),
@@ -63,41 +78,30 @@ public class Page extends Rectangle {
                 pdPage,
                 t,
                 Ruling.cropRulingsToArea(getRulings(), area),
-
-                Collections.min(t, new Comparator<TextElement>() {
-                    @Override
-                    public int compare(TextElement te1, TextElement te2) {
-                        return java.lang.Float.compare(te1.width, te2.width);
-                    }}).width,
-                
-                Collections.min(t, new Comparator<TextElement>() {
-                        @Override
-                        public int compare(TextElement te1, TextElement te2) {
-                            return java.lang.Float.compare(te1.height, te2.height);
-                }}).height,
-                
+                min_char_width,
+                min_char_height,                
                 spatial_index);
         
         rv.addRuling(new Ruling(
                 new Point2D.Double(rv.getLeft(), 
-                		rv.getTop()), 
+                    rv.getTop()), 
                 new Point2D.Double(rv.getRight(), 
-                		rv.getTop())));
+                    rv.getTop())));
         rv.addRuling(new Ruling(
                 new Point2D.Double(rv.getRight(), 
-                		rv.getTop()), 
+                    rv.getTop()), 
                 new Point2D.Double(rv.getRight(), 
-                		rv.getBottom())));
+                    rv.getBottom())));
         rv.addRuling(new Ruling(
                 new Point2D.Double(rv.getRight(), 
-                		rv.getBottom()), 
+                    rv.getBottom()), 
                 new Point2D.Double(rv.getLeft(), 
-                		rv.getBottom())));
+                    rv.getBottom())));
         rv.addRuling(new Ruling(
                 new Point2D.Double(rv.getLeft(), 
-                		rv.getBottom()), 
+                    rv.getBottom()), 
                 new Point2D.Double(rv.getLeft(), 
-                		rv.getTop())));
+                    rv.getTop())));
  
         return rv;
     }
@@ -221,7 +225,7 @@ public class Page extends Rectangle {
     }
 
     public PDPage getPDPage() {
-    	return pdPage;
+      return pdPage;
     }
 
     public RectangleSpatialIndex<TextElement> getSpatialIndex() {

--- a/src/main/java/technology/tabula/Page.java
+++ b/src/main/java/technology/tabula/Page.java
@@ -53,7 +53,6 @@ public class Page extends Rectangle {
     
     public Page getArea(Rectangle area) {
         List<TextElement> t = getText(area);
-        if (t.isEmpty()) return this;
         Page rv = new Page(
                 (float) area.getTop(),
                 (float) area.getLeft(),

--- a/src/main/java/technology/tabula/extractors/SpreadsheetExtractionAlgorithm.java
+++ b/src/main/java/technology/tabula/extractors/SpreadsheetExtractionAlgorithm.java
@@ -146,6 +146,12 @@ public class SpreadsheetExtractionAlgorithm implements ExtractionAlgorithm {
     
     public boolean isTabular(Page page) {
         
+        // if there's no text at all on the page, it's not a table 
+        // (we won't be able to do anything with it though)
+        if(page.getText().isEmpty()){
+            return false; 
+        }
+
         // get minimal region of page that contains every character (in effect,
         // removes white "margins")
         Page minimalRegion = page.getArea(Utils.bounds(page.getText()));

--- a/src/main/java/technology/tabula/json/TableSerializer.java
+++ b/src/main/java/technology/tabula/json/TableSerializer.java
@@ -17,9 +17,13 @@ public class TableSerializer implements JsonSerializer<Table> {
     @Override
     public JsonElement serialize(Table table, Type type,
             JsonSerializationContext context) {
-        
+
         JsonObject object = new JsonObject();
-        object.addProperty("extraction_method", table.getExtractionAlgorithm().toString());
+        if( table.getExtractionAlgorithm() == null){
+            object.addProperty("extraction_method", "");
+        }else{
+            object.addProperty("extraction_method", (table.getExtractionAlgorithm()).toString());
+        }
         object.addProperty("top", table.getTop());
         object.addProperty("left", table.getLeft());
         object.addProperty("width", table.getWidth());

--- a/src/test/java/technology/tabula/TestBasicExtractor.java
+++ b/src/test/java/technology/tabula/TestBasicExtractor.java
@@ -157,6 +157,10 @@ public class TestBasicExtractor {
         {"AARON, MICHAEL, R","","","BROOKLYN, NY","MEALS","$65.92"}
         };
 
+    private static final String[][] EXPECTED_EMPTY_TABLE = {
+        {""}
+    };
+
 
     @Test
     public void testRemoveSequentialSpaces() throws IOException {
@@ -355,6 +359,16 @@ public class TestBasicExtractor {
         StringBuilder sb = new StringBuilder();
         (new CSVWriter()).write(sb, table);
         assertEquals(expectedCsv, sb.toString());
+    }
+
+
+    @Test
+    public void testEmptyRegion() throws IOException {
+        Page page = UtilsForTesting.getAreaFromPage("src/test/resources/technology/tabula/indictb1h_14.pdf", 1,
+                        0.0f, 0.0f, 80.82f, 100.9f); // an empty area
+        BasicExtractionAlgorithm bea = new BasicExtractionAlgorithm();
+        Table table = bea.extract(page).get(0);
+        assertArrayEquals(EXPECTED_EMPTY_TABLE, UtilsForTesting.tableToArrayOfRows(table));
     }
 
 }


### PR DESCRIPTION
Previously, the Page class's `getArea` function would attempt to calculate minimum char width/height from the area's constituent characters. However, it would raise an exception if there were no characters. #131 attempted to fix this by returning the instance of Page, but, when an area was empty, calling `getText` on that area would incorrectly return the text of the whole page, not of the (empty) area. This pull request sets the minimum char width/height only if there's text in the area, avoiding the error.

Adds a test for this too.

Reverts #131. @jazzido: take a look and merge?