### PR TITLE
Prevent file creation in sources directory

### DIFF
--- a/src/test/java/technology/tabula/TestCommandLineApp.java
+++ b/src/test/java/technology/tabula/TestCommandLineApp.java
@@ -12,9 +12,14 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.ParseException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class TestCommandLineApp {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     private String csvFromCommandLineArgs(String[] args) throws ParseException {
         CommandLineParser parser = new DefaultParser();
@@ -72,7 +77,7 @@ public class TestCommandLineApp {
                 "src/test/resources/technology/tabula/spreadsheet_no_bounding_frame.pdf",
                 "-p", "1", "-a",
                 "150.56,58.9,654.7,536.12", "-f",
-                "CSV", "-o", "outputFile"
+                "CSV", "-o", folder.newFile().getAbsolutePath()
         });
         //assertEquals(expectedCsv,);
     }


### PR DESCRIPTION
The test seems to be a work-in-progress, and it fails if we fix the commented-out `assert` statement. But as is now, it creates an unnecessary `outputFile` in the sources directory.

This pull request addresses it by the use of JUnit 4.x's `TemporaryFolder` rule. I believe once the test is enabled, that can still be used. Or maybe we comment the complete test?

Hope it helps
Bruno