### PR TITLE
bugfix about snapping rulings and  path iterator

### DIFF
--- a/src/main/java/technology/tabula/ObjectExtractorStreamEngine.java
+++ b/src/main/java/technology/tabula/ObjectExtractorStreamEngine.java
@@ -179,11 +179,11 @@ class ObjectExtractorStreamEngine extends PDFGraphicsStreamEngine {
         Point2D.Float end_pos = null;
         Line2D.Float line;
         PointComparator pc = new PointComparator();
-        while (!pi.isDone()) {
+        while (true) {
             pi.next();
-            // This can be the last segment, when pi.isDone, but we need to
-            // process it
-            // otherwise us-017.pdf fails the last value.
+            if (pi.isDone()) {
+                break;
+            }
             try {
                 currentSegment = pi.currentSegment(c);
             } catch (IndexOutOfBoundsException ex) {

--- a/src/main/java/technology/tabula/Utils.java
+++ b/src/main/java/technology/tabula/Utils.java
@@ -211,7 +211,7 @@ public class Utils {
         List<List<Point2D>> groupedPoints = new ArrayList<>();
         groupedPoints.add(new ArrayList<>(Arrays.asList(new Point2D[]{points.get(0)})));
 
-        for (Point2D p : points.subList(1, points.size() - 1)) {
+        for (Point2D p : points.subList(1, points.size())) {
             List<Point2D> last = groupedPoints.get(groupedPoints.size() - 1);
             if (Math.abs(p.getX() - last.get(0).getX()) < xThreshold) {
                 groupedPoints.get(groupedPoints.size() - 1).add(p);
@@ -243,7 +243,7 @@ public class Utils {
         groupedPoints = new ArrayList<>();
         groupedPoints.add(new ArrayList<>(Arrays.asList(new Point2D[]{points.get(0)})));
 
-        for (Point2D p : points.subList(1, points.size() - 1)) {
+        for (Point2D p : points.subList(1, points.size())) {
             List<Point2D> last = groupedPoints.get(groupedPoints.size() - 1);
             if (Math.abs(p.getY() - last.get(0).getY()) < yThreshold) {
                 groupedPoints.get(groupedPoints.size() - 1).add(p);


### PR DESCRIPTION
Utils.java: 
- One less point was added to groupedPoints.
   second argument of List#subList() is not the number of  elements

ObjectExtractorStreamEngine.java: 
 - One more segment was referenced by the path iterator.
   pi.isDone() checks whether current segment is out of range,
   pi.next() moves current segment to the next.
   (Now "us-017.pdf" does not fail the last value)