### PR TITLE
Make RectangleSpatialIndex public, and usable to code that links with tabula-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>technology.tabula</groupId>
     <artifactId>tabula</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <name>Tabula</name>
     <description>Extract tables from PDF files</description>
     <url>http://github.com/tabulapdf/tabula-java</url>

--- a/src/main/java/technology/tabula/RectangleSpatialIndex.java
+++ b/src/main/java/technology/tabula/RectangleSpatialIndex.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.index.strtree.STRtree;
 
-class RectangleSpatialIndex<T extends Rectangle> {
+public class RectangleSpatialIndex<T extends Rectangle> {
     
 
     private final STRtree si = new STRtree();


### PR DESCRIPTION
As discussed in [#240](https://github.com/tabulapdf/tabula-java/issues/240), makes `RectangleSpatialIndex` public, which allows a custom `ObjectExtractor` to instantiate `Page` objects with spatial indices.