### PR TITLE
-g method translates to ExtractionMethod.DECIDE

### DIFF
--- a/src/main/java/technology/tabula/CommandLineApp.java
+++ b/src/main/java/technology/tabula/CommandLineApp.java
@@ -252,7 +252,7 @@ public class CommandLineApp {
         }
 
         // -n/--no-spreadsheet [deprecated; use -t] or  -c/--columns or -g/--guess or -t/--stream
-        if (line.hasOption('n') || line.hasOption('c') || line.hasOption('g') || line.hasOption('t')) {
+        if (line.hasOption('n') || line.hasOption('c') || line.hasOption('t')) {
             return ExtractionMethod.BASIC;
         }
         return ExtractionMethod.DECIDE;


### PR DESCRIPTION
will close #223 (this bug was just a coding error, where the "guess" method was hard-coded to the basic extraction method, rather than the `DECIDE` extraction method that it's meant to.