### PR TITLE
Fix excessive memory usage issue with large (many pages) PDFs

### DIFF
--- a/src/main/java/technology/tabula/Table.java
+++ b/src/main/java/technology/tabula/Table.java
@@ -1,5 +1,6 @@
 package technology.tabula;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
@@ -46,7 +47,7 @@ public class Table extends Rectangle {
 		this.memoizedRows = null;
 	}
 
-	private List<List<RectangularTextContainer>> memoizedRows = null;
+	private transient List<List<RectangularTextContainer>> memoizedRows = null;
 
 	public List<List<RectangularTextContainer>> getRows() {
 		if (this.memoizedRows == null) this.memoizedRows = computeRows();
@@ -73,7 +74,8 @@ public class Table extends Rectangle {
 
 }
 
-class CellPosition implements Comparable<CellPosition> {
+@SuppressWarnings("serial")
+class CellPosition implements Serializable, Comparable<CellPosition> {
 
 	CellPosition(int row, int col) {
 		this.row = row;

--- a/src/main/java/technology/tabula/TableWithRulingLines.java
+++ b/src/main/java/technology/tabula/TableWithRulingLines.java
@@ -11,8 +11,8 @@ import technology.tabula.extractors.ExtractionAlgorithm;
 @SuppressWarnings("serial")
 public class TableWithRulingLines extends Table {
 
-    List<Ruling> verticalRulings, horizontalRulings;
-    RectangleSpatialIndex<Cell> si = new RectangleSpatialIndex<>();
+    transient List<Ruling> verticalRulings, horizontalRulings;
+    transient RectangleSpatialIndex<Cell> si = new RectangleSpatialIndex<>();
     
     public TableWithRulingLines(Rectangle area, List<Cell> cells, List<Ruling> horizontalRulings, List<Ruling> verticalRulings, ExtractionAlgorithm extractionAlgorithm) {
         super(extractionAlgorithm);

--- a/src/main/java/technology/tabula/TextElement.java
+++ b/src/main/java/technology/tabula/TextElement.java
@@ -9,7 +9,7 @@ import org.apache.pdfbox.pdmodel.font.PDFont;
 public class TextElement extends Rectangle implements HasText {
 
     private final String text;
-    private final PDFont font;
+    transient private final PDFont font;
     private float fontSize;
     private float widthOfSpace, dir;
     private static final float AVERAGE_CHAR_TOLERANCE = 0.3f;

--- a/src/main/java/technology/tabula/detectors/NurminenDetectionAlgorithm.java
+++ b/src/main/java/technology/tabula/detectors/NurminenDetectionAlgorithm.java
@@ -117,6 +117,7 @@ public class NurminenDetectionAlgorithm implements DetectionAlgorithm {
         PDDocument removeTextDocument = null;
         try {
             removeTextDocument = this.removeText(pdfPage);
+            pdfPage = removeTextDocument.getPage(0);
             image = Utils.pageConvertToImage(pdfPage, 144, ImageType.GRAY);
         } catch (Exception e) {
             return new ArrayList<>();
@@ -856,16 +857,15 @@ public class NurminenDetectionAlgorithm implements DetectionAlgorithm {
         }
 
         PDDocument document = new PDDocument();
-        document.addPage(page);
+        PDPage newPage = document.importPage(page);
+        newPage.setResources(page.getResources());
 
         PDStream newContents = new PDStream(document);
         OutputStream out = newContents.createOutputStream(COSName.FLATE_DECODE);
         ContentStreamWriter writer = new ContentStreamWriter(out);
         writer.writeTokens(newTokens);
         out.close();
-        page.setContents(newContents);
-
+        newPage.setContents(newContents);
         return document;
-
     }
 }


### PR DESCRIPTION
I noticed that memory usage was growing steadily when processing a 700 page PDF. I was not intentionally accumulating anything in RAM (my code was detecting and extracting tables into a file as I iterated through the pages), so this was surprising.

It turned out that what I was seeing was that one ScratchFile instance per page processed was being retained until the PDDocument was closed.

I fixed this leak by changing the removeText method to use importPage instead of addPage so that the ScratchFiles go away when the temporary PDDocuments are GCed.