### PR TITLE
Implement line color filter

### DIFF
--- a/src/main/java/technology/tabula/CommandLineApp.java
+++ b/src/main/java/technology/tabula/CommandLineApp.java
@@ -44,6 +44,7 @@ public class CommandLineApp {
     private OutputFormat outputFormat;
     private String password;
     private TableExtractor tableExtractor;
+    private Integer lineColorFilter;
 
     public CommandLineApp(Appendable defaultOutput, CommandLine line) throws ParseException {
         this.defaultOutput = defaultOutput;
@@ -51,6 +52,7 @@ public class CommandLineApp {
         this.pages = CommandLineApp.whichPages(line);
         this.outputFormat = CommandLineApp.whichOutputFormat(line);
         this.tableExtractor = CommandLineApp.createExtractor(line);
+        this.lineColorFilter = CommandLineApp.whichLineColorFilter(line);
 
         if (line.hasOption('s')) {
             this.password = line.getOptionValue('s');
@@ -195,7 +197,7 @@ public class CommandLineApp {
     }
 
     private PageIterator getPageIterator(PDDocument pdfDocument) throws IOException {
-        ObjectExtractor extractor = new ObjectExtractor(pdfDocument);
+        ObjectExtractor extractor = new ObjectExtractor(pdfDocument, lineColorFilter);
         return (pages == null) ?
                 extractor.extract() :
                 extractor.extract(pages);
@@ -258,6 +260,23 @@ public class CommandLineApp {
             return ExtractionMethod.BASIC;
         }
         return ExtractionMethod.DECIDE;
+    }
+
+    private static Integer whichLineColorFilter(CommandLine line) throws ParseException {
+        if (!line.hasOption("line-color-filter")) {
+            return null;
+        }
+
+        Integer result;
+        try {
+            result = Integer.parseInt(line.getOptionValue("line-color-filter"));
+        } catch (NumberFormatException e) {
+            throw new ParseException("line-color-filter parameter must be a hexadecimal number");
+        }
+        if (result < 0 || result > 0xFFFFFF) {
+            throw new ParseException("line-color-filter parameter must be at most FFFFFF");
+        }
+        return result;
     }
 
     private static TableExtractor createExtractor(CommandLine line) throws ParseException {
@@ -357,6 +376,12 @@ public class CommandLineApp {
                 .desc("Comma separated list of ranges, or all. Examples: --pages 1-3,5-7, --pages 3 or --pages all. Default is --pages 1")
                 .hasArg()
                 .argName("PAGES")
+                .build());
+        o.addOption(Option.builder(null)
+                .longOpt("line-color-filter")
+                .desc("Only consider lines of this color to be lattice lines. Example: --line-color-filter DEADBE .")
+                .hasArg()
+                .argName("COLOR")
                 .build());
 
         return o;

--- a/src/main/java/technology/tabula/ObjectExtractor.java
+++ b/src/main/java/technology/tabula/ObjectExtractor.java
@@ -8,9 +8,15 @@ import org.apache.pdfbox.pdmodel.PDPage;
 public class ObjectExtractor implements java.io.Closeable {
 
     private final PDDocument pdfDocument;
+    private final Integer lineColorFilter;
 
     public ObjectExtractor(PDDocument pdfDocument) {
+        this(pdfDocument, null);
+    }
+
+    public ObjectExtractor(PDDocument pdfDocument, Integer lineColorFilter) {
         this.pdfDocument = pdfDocument;
+        this.lineColorFilter = lineColorFilter;
     }
 
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //
@@ -20,7 +26,7 @@ public class ObjectExtractor implements java.io.Closeable {
         }
         PDPage page = pdfDocument.getPage(pageNumber - 1);
 
-        ObjectExtractorStreamEngine streamEngine = new ObjectExtractorStreamEngine(page);
+        ObjectExtractorStreamEngine streamEngine = new ObjectExtractorStreamEngine(page, lineColorFilter);
         streamEngine.processPage(page);
 
         TextStripper textStripper = new TextStripper(pdfDocument, pageNumber);


### PR DESCRIPTION
Addresses #21.

I've never worked with PDFBox before, so I hope this is the right approach -- it works at least for [this file](https://github.com/tabulapdf/tabula-java/files/6427412/uebersicht_AstraZeneca-Impfpraxen_0504.pdf) (without the color filter, some of the underlines for the hyperlinks are detected as rulings, which splits those rows). However, it doesn't work for [this file](https://github.com/tabulapdf/tabula-java/files/6427466/rulings_color_crop.pdf) (without the color filter, it simply detects all cells as separate). With the color filter, it exports the following CSV:

    A,B
    4","2
    5,6

Is this an issue with the color filter or is it related to the red and black lines crossing?

Other notes:

- I'm not sure if this is a good way to pass the line color filter argument to the ```ObjectExtractorStreamEngine```.
- I haven't added tests yet. I should hopefully have some time next week to debug further and add them.
- I couldn't come up with a sensible short-style command line option, so I only added a long-style one.
