### PR TITLE
add ffi constructor to CommandLineApp

### DIFF
--- a/src/main/java/technology/tabula/CommandLineApp.java
+++ b/src/main/java/technology/tabula/CommandLineApp.java
@@ -6,6 +6,7 @@ import java.io.FilenameFilter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -56,6 +57,22 @@ public class CommandLineApp {
             this.password = line.getOptionValue('s');
         }
     }
+
+	public CommandLineApp(Pair<Integer, Rectangle>[] page_areas, Integer[] pages, OutputFormat output_format, boolean guess, ExtractionMethod extraction_method, boolean use_returns, String password) throws ParseException {
+		if (page_areas != null)
+			this.pageAreas = Arrays.asList(page_areas);
+		if (pages != null)
+			this.pages = Arrays.asList(pages);
+		this.outputFormat = output_format;
+
+		TableExtractor extractor = new TableExtractor();
+		extractor.setGuess(guess);
+		extractor.setMethod(extraction_method);
+		extractor.setUseLineReturns(use_returns);
+		this.tableExtractor = extractor;
+
+		this.password = password;
+	}
 
     public static void main(String[] args) {
         CommandLineParser parser = new DefaultParser();

--- a/src/main/java/technology/tabula/writers/CSVWriter.java
+++ b/src/main/java/technology/tabula/writers/CSVWriter.java
@@ -20,7 +20,7 @@ public class CSVWriter implements Writer {
     }
 
     protected CSVWriter(CSVFormat format) {
-        this.format = format;
+        this.format = format.withRecordSeparator("\n");
     }
 
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - //


### PR DESCRIPTION
Good evening,
I've created [tabula-java](https://github.com/tabulapdf/tabula-java/) bindings for Rust:
[tabula-rs forge](https://github.com/sp1ritCS/tabula-rs) & [tabula on crates.io](https://crates.io/crates/tabula)

However, as I'm using JNI rather than shelling out java, I need some way of constructing the `CommandLineApp` object. This patch adds a constructor with more primitive (array instead of List) parameters that allow creating `CommandLineApp`  programmatically (ik. this "technically" isn't a "CommandLine Application" anymore 🙃).

I also needed the `CSVWriter` to write newlines as LF, as at least the test files you provide are also ending with LF (otherwise my tests fail).

It's been years since years since I have last written Java, but I don't think I made any major mistake :D (but if I did, please excuse me ;)).

Signed-off-by: Florian "sp1rit"​ <sp1ritCS@protonmail.com>