### PR TITLE
Upgrade BouncyCastle dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,14 +268,14 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.80</version>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcmail-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcmail-jdk18on</artifactId>
+            <version>1.80</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR is a small version bump for the Bouncy Castle dependencies:

- [`org.bouncycastle.bcprov-jdk15on:1.70`](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on) → [`org.bouncycastle.bcprov-jdk18on:1.80`](https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on)
- [`org.bouncycastle.bcmail-jdk15on:1.70`](https://mvnrepository.com/artifact/org.bouncycastle/bcmail-jdk15on) → [`org.bouncycastle.bcmail-jdk18on:1.80`](https://mvnrepository.com/artifact/org.bouncycastle/bcmail-jdk18on)

This upgrade was motivated by the known CVEs affecting the current versions of these Bouncy Castle dependencies. I haven't tried to do an analysis to tell if these CVEs are applicable in the context of Tabula or not, but it seemed like upgrading was pretty straightforward. I believe Dependabot didn't catch this since the Maven artifact was effectively replaced (from `jdk15on` to `jdk18on`).

I haven't tested this PR extensively, but the code compiled without issues, it passed tests in CI, and it also still worked with some internal tooling I tried out. I also haven't tested with different JDK versions, but based on the Bouncy Castle artifact name change, I'm assuming that this change won't work for JDK versions < 18 (I'm also not sure what the minimum JDK version `tabula-java` itself supports).